### PR TITLE
Refactor fotofetch.rb

### DIFF
--- a/lib/fotofetch.rb
+++ b/lib/fotofetch.rb
@@ -5,43 +5,33 @@ require 'fastimage'
 
 module Fotofetch
   class Fetch
-    attr_reader :topic, :results
     attr_accessor :options
 
-    def initialize(topic="", options={})
-      @topic = topic
-      @options = default_options.merge(options)
-    end
-
-    def default_amount; 1; end
-    def default_height; 9999; end
-    def default_width; 9999; end
-    def default_search_url; "http://www.bing.com/images/search?q="; end
-
     def default_options
-      { amount: default_amount,
-        width: default_width,
-        height: default_height,
-        search_url: default_search_url }
+      { amount: 1,
+        width: 9999,
+        height: 9999,
+        search_url: "http://www.bing.com/images/search?q=" }
     end
 
-    def fetch_links(topic, amount=self.default_amount, width=self.default_width,
-                    height=self.default_height)
+    def fetch_links(topic, amount=default_options[:amount],
+      width=default_options[:width], height=default_options[:height])
+      @topic = topic
       create_options(amount, width, height)
-      @topic = topic if !topic.nil?
 
-      page = scrape(self.topic)
+      page = scrape(@topic)
       urls = pluck_urls(page)
       imgs = pluck_imgs(urls)
       imgs = restrict_dimensions(imgs, self.options)
-      @results = add_sources(imgs)
+      results = add_sources(imgs)
     end
 
     def create_options(amount, width, height)
-      # if custom options were provided in init, they will not be overriden
-      self.options[:amount] = amount if amount != default_amount
-      self.options[:width] = width if width != default_width
-      self.options[:height] = height if height!= default_height
+      self.options = default_options.merge({
+        amount: amount,
+        width: width,
+        height: height
+      })
     end
 
     def scrape(topic)
@@ -110,7 +100,7 @@ module Fotofetch
     end
 
     def link_dimensions(link)
-      # nil results in [0,0] which means is non-direct-image link
+      # nil from FastImate will return [0,0] which means non-direct-image link
       FastImage.size(link) || [0,0]
     end
   end

--- a/lib/fotofetch.rb
+++ b/lib/fotofetch.rb
@@ -87,7 +87,9 @@ module Fotofetch
 
     # Adds root urls as hash keys
     def add_sources(urls)
-      urls.map { |link| [root_url(link), link] }.to_h
+      urls.each_with_object( {}.compare_by_identity ) do |link, pairs|
+        pairs[root_url(link)] = link
+      end
     end
 
     # takes an array of links


### PR DESCRIPTION
This is a refactor.. No tests were changed or added. However, it does pave the way for adding an initialize that takes a topic and optional options hash, which is a rails convention and I think a good one. It allows you to change options without changing what is exposed as the external interface. See the "refactor" branch on my fork of this to see it taken a little further (or just look at the first commit in this one.. I shrunk it after the initial one). And the next step after that would be doing things that change the interface, change the tests, and force anyone who is using the gem to change what they're doing.

Here's some of the changes made:
- define defaults in a default_options method. previously they were defined in multiple places which can be problematic. the whole "magic number" issue.
- rework fetch_links to accumlate results, as opposed to chained, interdependent methods.
- left width_ok? and size_ok? methods alone as i really can't tell exactly what they're doing.
  a possible to do would be to redefine these to use descriptive variable or key names, as opposed
  to [0][1], etc. but i didn't know what those descriptive variable names should be, so i left it
- shortened up some enumerables, broke out some items to their own methods, like root_url

i hope this helps. let me know if you have questions or want to see it taken a different direction.
